### PR TITLE
fix qmd.x error when print(molecular dipolemoment) is enabled with static sampling properties

### DIFF
--- a/src/kinetic.f90
+++ b/src/kinetic.f90
@@ -240,6 +240,7 @@ subroutine kinetic_acmd(p,na,tk,rmass,nb,beta,om)
         endif
      enddo
   enddo
+  deallocate (ptemp)
   
   return
 end subroutine kinetic_acmd

--- a/src/md_dynamics.f90
+++ b/src/md_dynamics.f90
@@ -337,6 +337,7 @@ endif
 66  format(1x,'<PE> = ',f10.4,' Kj/mol')
 
     deallocate (ct,dct,rmtr,irmtr,rmtv,irmtv,dmtr,idmtr,dmtv,idmtv,dmo1,dmot1)
+    deallocate (cvinter,dcvinter,cvintra,dcvintra,cke,dke,ihhh,ihoo,ihoh)
 #ifdef PARALLEL_BINDING
 endif
 #endif

--- a/src/md_static.f90
+++ b/src/md_static.f90
@@ -107,7 +107,7 @@ subroutine md_static_prepare_traj(nb,pt,pb,print,reftraj,printNPT,printMSD)
         end do
         if (print_set_element(4))then
             worked = fh_mol_dipole%open(STATUS=file_status,ACTION='write',&
-            POSITION='file_position')
+            POSITION=file_position)
         endif
     endif
     !-----------------------------------------------


### PR DESCRIPTION
For an MD simulation, when I enabled the print for molecular dipole moment (the last 1 in the print option), along with static sampling steps (ng), it resulted in a qmd.x crash.

On further debugging the source code, I observed that in the function "md_static_prepare_traj" at line 110, the string "file_position" is again passed in quotes "". This was resulting in a qmd.x crash with the following error message: "Bad POSITION parameter in"

I have made a small fix for this typo error and found the qmd.x working for the given scenario. 

[Input_water_acmd.txt](https://github.com/user-attachments/files/21720537/Input_water_acmd.txt)

